### PR TITLE
use rawgit cdn links as recommended, and protocol-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 This is a [Stan](http://mc-stan.org) implementation of Drew Linzer's dynamic Bayesian election forecasting model, with some tweaks to incorporate national poll data, pollster house effects, correlated priors on state-by-state election results and comovement of public opinion across states. 
 
-The model is presented briefly at the end of [`report.html`](https://rawgit.com/pkremp/polls/master/report.html).
+The model is presented briefly at the end of [`report.html`](//cdn.rawgit.com/pkremp/polls/master/report.html).
 
 `runmodel.R` downloads poll data from the HuffPost Pollster API, processes the data, and runs the Stan model in `state and national polls.stan`.
 
-`report.Rmd` is a Rmarkdown document used to automatically generate the graphs/tables/maps in [`report.html`](https://rawgit.com/pkremp/polls/master/report.html) and relies on `graphs.R`.
+`report.Rmd` is a Rmarkdown document used to automatically generate the graphs/tables/maps in [`report.html`](//cdn.rawgit.com/pkremp/polls/master/report.html) and relies on `graphs.R`.
 
 


### PR DESCRIPTION
First, awesome work. Thanks for making this!
Second, in order to share it widely in your current setup using rawgit, you really need to publish cdn links per [rawgit faq](https://github.com/rgrove/rawgit/wiki/Frequently-Asked-Questions#can-i-use-a-rawgitcom-development-url-on-a-production-website-or-in-public-example-code). The first several times I tried to open the document I got [503 Service Unavailable](https://http.cat/503) because of the throttling they threaten. I’ve changed it here in the readme but I wanted to let you know as you otherwise spread the word about the report.

Third, why not use github pages instead? Would you be interested in a PR that did that? 