### PR TITLE
Avoid error with NA (0) response for T or C

### DIFF
--- a/runmodel.R
+++ b/runmodel.R
@@ -102,6 +102,8 @@ df <- all_polls %>%
            pollster = replace(pollster, pollster == "WashPost", "Washington Post"),
            pollster = replace(pollster, pollster == "ABC News", "ABC"),
            undecided = ifelse(is.na(undecided), 0, undecided),
+           clinton = ifelse(is.na(clinton), 0, clinton),
+           trump = ifelse(is.na(trump), 0, trump),
            other = ifelse(is.na(other), 0, other) + 
                ifelse(is.na(johnson), 0, johnson) + 
                ifelse(is.na(mcmullin), 0, mcmullin),


### PR DESCRIPTION
The 2016-11-06 SurveyMonkey result for TN, quoted below, resulted in an error

"2874","TN","SurveyMonkey","2016-10-30","2016-11-06","2016-11-07T05:29:35Z",1281,"Likely Voters","Internet",NA,89,9,2,"http://elections.huffingtonpost.com/pollster/polls/surveymonkey-26769","https://www.surveymonkey.com/elections/map?poll=sm-lv-cpsplus","Nonpartisan","None","",1,NA,NA

NOTE: the polling result may itself be an error! but it exposed this bug.